### PR TITLE
Add NAVHISTORY search variant patch

### DIFF
--- a/patches.def.h
+++ b/patches.def.h
@@ -166,6 +166,13 @@
  */
 #define NAVHISTORY_PATCH 0
 
+/* This patch extends NAVHISTORY_PATCH with history-search functionality, replacing program
+ * suggestions with previously issued commands stored in history.
+ * This variant depends on NAVHISTORY_PATCH being enabled.
+ * https://tools.suckless.org/dmenu/patches/navhistory/
+ */
+#define NAVHISTORY_SEARCH_PATCH 0
+
 /* Adds the -S option to disable sorting menu items after matching. Useful, for example, when menu
  * items are sorted by their frequency of use (using an external cache) and the most frequently
  * selected items should always appear first regardless of how they were exact, prefix, or
@@ -332,3 +339,4 @@
  * https://tools.suckless.org/dmenu/patches/xyw/
  */
 #define XYW_PATCH 0
+


### PR DESCRIPTION
The NAVHISTORY patch on the Suckless site provides an extra variant of the patch allowing to switch between suggestions for installed programs and suggestions for previously issued shell commands. I figured this might be a useful variant to add to flexipatch since I've recently made good use of dmenu to run such commands, e.g. to run programs via dmenu with certain environment variables set in advance.

That being said, it does seem like this patch is a bit buggy or otherwise slightly unintuitive. In particular,
- Pressing Ctrl+R to switch to history-search mode doesn't happen instantaneously and requires invoking NAVHISTORY first with Alt+P
- Pressing Ctrl+R a second time simply closes dmenu rather than reverting it to program-suggestion mode.

Unfortunately, I lack the expertise to fix those issues, though I would love to know how to solve that to make this patch that bit more worth using.