### PR TITLE
Remove fuzzyhighlight precedence over hightlight patch

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -199,6 +199,13 @@ static void appenditem(struct item *item, struct item **list, struct item **last
 static void calcoffsets(void);
 static void cleanup(void);
 static char * cistrstr(const char *s, const char *sub);
+#if HIGHLIGHT_PATCH || FUZZYHIGHLIGHT_PATCH
+#if EMOJI_HIGHLIGHT_PATCH
+static void drawhighlights(struct item *item, char *output, int x, int y, int maxw);
+#else
+static void drawhighlights(struct item *item, int x, int y, int maxw);
+#endif // EMOJI_HIGHLIGHT_PATCH
+#endif // HIGHLIGHT_PATCH || FUZZYHIGHLIGHT_PATCH
 static int drawitem(struct item *item, int x, int y, int w);
 static void drawmenu(void);
 static void grabfocus(void);
@@ -299,6 +306,36 @@ cistrstr(const char *s, const char *sub)
 			return (char *)s;
 	return NULL;
 }
+
+#if HIGHLIGHT_PATCH || FUZZYHIGHLIGHT_PATCH
+static void
+#if EMOJI_HIGHLIGHT_PATCH
+drawhighlights(struct item *item, char *output, int x, int y, int maxw)
+#else // EMOJI_HIGHLIGHT_PATCH
+drawhighlights(struct item *item, int x, int y, int maxw)
+#endif
+{
+#if FUZZYHIGHLIGHT_PATCH
+    if (fuzzy) {
+#if EMOJI_HIGHLIGHT_PATCH
+        drawhighlights_fuzzy(item, output, x, y, maxw);
+#else
+        drawhighlights_fuzzy(item, x, y, maxw);
+#endif // EMOJI_HIGHLIGHT_PATCH
+    }
+#endif // FUZZYHIGHLIGHT_PATCH
+
+#if HIGHLIGHT_PATCH
+    if (!fuzzy) {
+#if EMOJI_HIGHLIGHT_PATCH
+        drawhighlights_normal(item, output, x, y, maxw);
+#else
+        drawhighlights_normal(item, x, y, maxw);
+#endif // EMOJI_HIGHLIGHT_PATCH
+    }
+#endif // HIGHLIGHT_PATCH
+}
+#endif // HIGHLIGHT_PATCH || FUZZYHIGHLIGHT_PATCH
 
 static int
 drawitem(struct item *item, int x, int y, int w)

--- a/patch/fuzzyhighlight.c
+++ b/patch/fuzzyhighlight.c
@@ -1,8 +1,8 @@
 static void
 #if EMOJI_HIGHLIGHT_PATCH
-drawhighlights(struct item *item, char *output, int x, int y, int maxw)
+drawhighlights_fuzzy(struct item *item, char *output, int x, int y, int maxw)
 #else
-drawhighlights(struct item *item, int x, int y, int maxw)
+drawhighlights_fuzzy(struct item *item, int x, int y, int maxw)
 #endif // EMOJI_HIGHLIGHT_PATCH
 {
 	int i, indent;

--- a/patch/highlight.c
+++ b/patch/highlight.c
@@ -1,8 +1,8 @@
 static void
 #if EMOJI_HIGHLIGHT_PATCH
-drawhighlights(struct item *item, char *output, int x, int y, int maxw)
+drawhighlights_normal(struct item *item, char *output, int x, int y, int maxw)
 #else
-drawhighlights(struct item *item, int x, int y, int maxw)
+drawhighlights_normal(struct item *item, int x, int y, int maxw)
 #endif // EMOJI_HIGHLIGHT_PATCH
 {
 	char restorechar, tokens[sizeof text], *highlight,  *token;

--- a/patch/include.c
+++ b/patch/include.c
@@ -3,7 +3,8 @@
 #endif
 #if FUZZYHIGHLIGHT_PATCH
 #include "fuzzyhighlight.c"
-#elif HIGHLIGHT_PATCH
+#endif
+#if HIGHLIGHT_PATCH
 #include "highlight.c"
 #endif
 #if FUZZYMATCH_PATCH


### PR DESCRIPTION
Each patch introduces it's version of `drawhighlights` (`_fuzzy` and `_normal`), and we decide which one to run based on `fuzzy`. So if we disable fuzzy matching, normal highlighting it's used.