### PR TITLE
Fix window embedding with XRESOURCES_PATCH enabled

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -1907,6 +1907,16 @@ main(int argc, char *argv[])
 		die("cannot open display");
 	screen = DefaultScreen(dpy);
 	root = RootWindow(dpy, screen);
+
+	// Prior pass for `embed` is necessary
+	for (i = 0; i < argc; i++) {
+		if (!strcmp(argv[i], "-w")) {
+			embed = argv[++i];
+			break;
+		}
+	}
+	i = 0;
+
 	if (!embed || !(parentwin = strtol(embed, NULL, 0)))
 		parentwin = root;
 	if (!XGetWindowAttributes(dpy, parentwin, &wa))


### PR DESCRIPTION
Window embedding was broken with the XRESOURCES patch because the parent window computation was happening before the args were passed. This PR moves that section to after args have been passed.

Here's the picture of this working:
![image](https://user-images.githubusercontent.com/31820255/219926436-9d188c15-65be-4688-8eaf-59646757ba84.png)
