### PR TITLE
input method patch

### DIFF
--- a/patches.def.h
+++ b/patches.def.h
@@ -347,3 +347,7 @@
  * https://tools.suckless.org/dmenu/patches/xyw/
  */
 #define XYW_PATCH 0
+
+/* Adds support for input methods (fctix, ibus, etc.)
+*/
+#define INPUTMETHOD_PATCH 0


### PR DESCRIPTION
A new INPUTMETHOD_PATCH for dmenu to support input method (fctix, ibus). I've been using this for a while with fcitx and it's stable. The implementation is completely borrowed from [xprompt](https://github.com/phillbush/xprompt).

![Peek 2023-04-21 17-02](https://user-images.githubusercontent.com/26150581/233725363-44f3cf87-3cb2-4b2e-b8d8-cb682cd9eb34.gif)

the preview feature is not implemented, the text is just copied once you commit. Also not sure if all patches compile, I've just made sure it worked with the ones I'm using, hence a draft.
