### PR TITLE
Add highlight for mouse hover

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -1527,6 +1527,11 @@ run(void)
 		case ButtonPress:
 			buttonpress(&ev);
 			break;
+		#if MOTION_SUPPORT_PATCH
+		case MotionNotify:
+			mousemove(&ev);
+			break;
+		#endif // MOTION_SUPPORT_PATCH
 		#endif // MOUSE_SUPPORT_PATCH
 		case DestroyNotify:
 			if (ev.xdestroywindow.window != win)
@@ -1749,6 +1754,9 @@ setup(void)
 	swa.event_mask = ExposureMask | KeyPressMask | VisibilityChangeMask
 		#if MOUSE_SUPPORT_PATCH
 		| ButtonPressMask
+		#if MOTION_SUPPORT_PATCH
+		| PointerMotionMask
+		#endif // MOTION_SUPPORT_PATCH
 		#endif // MOUSE_SUPPORT_PATCH
 	;
 	win = XCreateWindow(

--- a/dmenu.c
+++ b/dmenu.c
@@ -1529,7 +1529,7 @@ run(void)
 			break;
 		#if MOTION_SUPPORT_PATCH
 		case MotionNotify:
-			mousemove(&ev);
+			motionevent(&ev.xbutton);
 			break;
 		#endif // MOTION_SUPPORT_PATCH
 		#endif // MOUSE_SUPPORT_PATCH

--- a/patch/mousesupport.c
+++ b/patch/mousesupport.c
@@ -160,36 +160,25 @@ buttonpress(XEvent *e)
 
 #if MOTION_SUPPORT_PATCH
 static void
-mousemove(XEvent *e)
+motionevent(XButtonEvent *ev)
 {
-	struct item *item;
-	XPointerMovedEvent *ev = &e->xmotion;
-	int x = 0, y = 0, h = bh, w;
+	struct item *it;
+	int xy, ev_xy;
 
-	if (lines > 0) {
-		w = mw - x;
-		for (item = curr; item != next; item = item->right) {
-			y += h;
-			if (ev->y >= y && ev->y <= (y + h)) {
-				sel = item;
-				calcoffsets();
-				drawmenu();
-				return;
-			}
+	if (ev->window != win || matches == 0)
+		return;
+
+	xy = lines > 0 ? bh : inputw + promptw + TEXTW("<");
+	ev_xy = lines > 0 ? ev->y : ev->x;
+	for (it = curr; it && it != next; it = it->right) {
+		int wh = lines > 0 ? bh : textw_clamp(it->text, mw - xy - TEXTW(">"));
+		if (ev_xy >= xy && ev_xy < (xy + wh)) {
+			sel = it;
+			calcoffsets();
+			drawmenu();
+			break;
 		}
-	} else if (matches) {
-		x += inputw + promptw;
-		w = TEXTW("<");
-		for (item = curr; item != next; item = item->right) {
-			x += w;
-			w = MIN(TEXTW(item->text), mw - x - TEXTW(">"));
-			if (ev->x >= x && ev->x <= x + w) {
-				sel = item;
-				calcoffsets();
-				drawmenu();
-				return;
-			}
-		}
+		xy += wh;
 	}
 }
 #endif

--- a/patch/mousesupport.c
+++ b/patch/mousesupport.c
@@ -157,3 +157,39 @@ buttonpress(XEvent *e)
 		}
 	}
 }
+
+#if MOTION_SUPPORT_PATCH
+static void
+mousemove(XEvent *e)
+{
+	struct item *item;
+	XPointerMovedEvent *ev = &e->xmotion;
+	int x = 0, y = 0, h = bh, w;
+
+	if (lines > 0) {
+		w = mw - x;
+		for (item = curr; item != next; item = item->right) {
+			y += h;
+			if (ev->y >= y && ev->y <= (y + h)) {
+				sel = item;
+				calcoffsets();
+				drawmenu();
+				return;
+			}
+		}
+	} else if (matches) {
+		x += inputw + promptw;
+		w = TEXTW("<");
+		for (item = curr; item != next; item = item->right) {
+			x += w;
+			w = MIN(TEXTW(item->text), mw - x - TEXTW(">"));
+			if (ev->x >= x && ev->x <= x + w) {
+				sel = item;
+				calcoffsets();
+				drawmenu();
+				return;
+			}
+		}
+	}
+}
+#endif

--- a/patches.def.h
+++ b/patches.def.h
@@ -141,6 +141,11 @@
  */
 #define MOUSE_SUPPORT_PATCH 0
 
+/* Expands the above to support mouse hovering.
+ * https://tools.suckless.org/dmenu/patches/mouse-support/
+ */
+#define MOTION_SUPPORT_PATCH 0
+
 /* Without this patch when you press Ctrl+Enter dmenu just outputs current item and it is not
  * possible to undo that.
  * With this patch dmenu will output all selected items only on exit. It is also possible to


### PR DESCRIPTION
To my surprise the [mouse support patch](https://tools.suckless.org/dmenu/patches/mouse-support/) does not highlight an entry when hovering by default.

I applied [this patch](https://tools.suckless.org/dmenu/patches/mouse-support/dmenu-mousesupporthoverbgcol-20210123-1a13d04.diff) from the same author that brings back motion support.

Also wanted to thank you for all these projects, you made ricing much more enjoyable.