### PR TITLE
Add support for the desktoponly patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ include config.mk
 SRC = drw.c dmenu.c stest.c util.c
 OBJ = $(SRC:.c=.o)
 
+desktoponly = false
+
 all: dmenu stest
 
 .c.o:
@@ -30,19 +32,35 @@ clean:
 
 dist: clean
 	mkdir -p dmenu-$(VERSION)
+ifeq ($(desktoponly), true)
+	cp LICENSE Makefile README arg.h config.def.h config.mk dmenu.1\
+		drw.h util.h dmenu_path dmenu_path_desktop dmenu_run dmenu_run_desktop stest.1 $(SRC)\
+		dmenu-$(VERSION)
+else
 	cp LICENSE Makefile README arg.h config.def.h config.mk dmenu.1\
 		drw.h util.h dmenu_path dmenu_run stest.1 $(SRC)\
 		dmenu-$(VERSION)
+endif
 	tar -cf dmenu-$(VERSION).tar dmenu-$(VERSION)
 	gzip dmenu-$(VERSION).tar
 	rm -rf dmenu-$(VERSION)
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
+ifeq ($(desktoponly), true)
+	cp -f dmenu dmenu_path dmenu_path_desktop dmenu_run dmenu_run_desktop stest $(DESTDIR)$(PREFIX)/bin
+else
 	cp -f dmenu dmenu_path dmenu_run stest $(DESTDIR)$(PREFIX)/bin
+endif
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/dmenu
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/dmenu_path
+ifeq ($(desktoponly), true)
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/dmenu_path_desktop
+endif
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/dmenu_run
+ifeq ($(desktoponly), true)
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/dmenu_run_desktop
+endif
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/stest
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	sed "s/VERSION/$(VERSION)/g" < dmenu.1 > $(DESTDIR)$(MANPREFIX)/man1/dmenu.1
@@ -51,11 +69,22 @@ install: all
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/stest.1
 
 uninstall:
+ifeq ($(desktoponly), true)
+	rm -f $(DESTDIR)$(PREFIX)/bin/dmenu\
+		$(DESTDIR)$(PREFIX)/bin/dmenu_path\
+		$(DESTDIR)$(PREFIX)/bin/dmenu_path_desktop\
+		$(DESTDIR)$(PREFIX)/bin/dmenu_run\
+		$(DESTDIR)$(PREFIX)/bin/dmenu_run_desktop\
+		$(DESTDIR)$(PREFIX)/bin/stest\
+		$(DESTDIR)$(MANPREFIX)/man1/dmenu.1\
+		$(DESTDIR)$(MANPREFIX)/man1/stest.1
+else
 	rm -f $(DESTDIR)$(PREFIX)/bin/dmenu\
 		$(DESTDIR)$(PREFIX)/bin/dmenu_path\
 		$(DESTDIR)$(PREFIX)/bin/dmenu_run\
 		$(DESTDIR)$(PREFIX)/bin/stest\
 		$(DESTDIR)$(MANPREFIX)/man1/dmenu.1\
 		$(DESTDIR)$(MANPREFIX)/man1/stest.1
+endif
 
 .PHONY: all clean dist install uninstall

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Browsing patches? There is a [map of patches](https://coggle.it/diagram/YjT2DD6j
 
 ### Changelog:
 
+2026-01-03 - Added the desktoponly patch (requires setting the desktoponly variable to "true" on the Makefile)
+
 2025-11-29 - Added the bidi patch
 
 2025-10-16 - Added the dynamic height and quiet patches
@@ -111,6 +113,12 @@ Browsing patches? There is a [map of patches](https://coggle.it/diagram/YjT2DD6j
 
    - [colored caret](https://tools.suckless.org/dmenu/patches/colored-caret/)
       - adds the `SchemeCaret` colour scheme allowing customised styling of the caret
+
+   - [desktoponly](https://tools.suckless.org/dmenu/patches/desktoponly/)
+      - allows dmenu to use only desktop files from /usr/share/applications
+         - requires changing the Makefile variable desktoponly to "true"
+         - requires gtk-launch to be present (part of gtk3 on some distros)
+         - requires xargs (part of findutils on some distros)
 
    - [dynamic height](https://gist.github.com/mircodz/1d9b88db958089bb08adbf45eb53b66f)
       - adjusts the height of the bar depending on how many items are drawn in the list presentation

--- a/dmenu_path_desktop
+++ b/dmenu_path_desktop
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cachedir="${XDG_CACHE_HOME:-"$HOME/.cache"}"
+cache="$cachedir/dmenu_run_desktop"
+
+[ ! -e "$cachedir" ] && mkdir -p "$cachedir"
+
+dirs=""
+IFS=:
+for dir in "${XDG_DATA_DIRS:-"$HOME/.local/share:/usr/local/share:/usr/share"}"; do
+	dirs="${dirs}:${dir}/applications"
+done;
+
+if stest -dqr -n "$cache" $PATH; then
+	stest -fl $dirs | grep -v 'mimeinfo.cache' | sed 's/\.[^./]*$//' | sort -u | tee "$cache"
+else
+	cat "$cache"
+fi

--- a/dmenu_run_desktop
+++ b/dmenu_run_desktop
@@ -1,0 +1,2 @@
+#!/bin/sh
+dmenu_path_desktop | dmenu "$@" | xargs gtk-launch &


### PR DESCRIPTION
The intend is to provide support for the [desktoponly](https://tools.suckless.org/dmenu/patches/desktoponly) patch, see issue #41 