### PR TITLE
feat: add search to navhistory patch

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -113,7 +113,7 @@ static char pipeout[8] = " | dmenu";
 static char *embed;
 #if SEPARATOR_PATCH
 static char separator;
-static int separator_greedy;
+static char * (*sepchr)(const char *, int);
 static int separator_reverse;
 #endif // SEPARATOR_PATCH
 static int bh, mw, mh;
@@ -205,6 +205,9 @@ static size_t nextrune(int inc);
 static void movewordedge(int dir);
 static void keypress(XKeyEvent *ev);
 static void paste(void);
+static void printitem(struct item *item);
+static void printtext(char *text);
+static void printcurrent(unsigned int state);
 #if ALPHA_PATCH
 static void xinitvisual(void);
 #endif // ALPHA_PATCH
@@ -983,7 +986,7 @@ match(void)
 
 	#if INSTANT_PATCH
 	if (instant && matches && matches==matchend && !lsubstr) {
-		puts(matches->text);
+		printitem(matches);
 		cleanup();
 		exit(0);
 	}
@@ -1344,85 +1347,11 @@ insert:
 			break;
 		#endif // RESTRICT_RETURN_PATCH
 		#if !MULTI_SELECTION_PATCH
-		#if PIPEOUT_PATCH
-		#if PRINTINPUTTEXT_PATCH
-		if (sel && (
-			(use_text_input && (ev->state & ShiftMask)) ||
-			(!use_text_input && !(ev->state & ShiftMask))
-		))
-		#else
-		if (sel && !(ev->state & ShiftMask))
-		#endif // PRINTINPUTTEXT_PATCH
-		{
-			if (sel->text[0] == startpipe[0]) {
-				strncpy(sel->text + strlen(sel->text),pipeout,8);
-				puts(sel->text+1);
-			}
-			#if PRINTINDEX_PATCH
-			if (print_index)
-				printf("%d\n", sel->index);
-			else
-			#if SEPARATOR_PATCH
-				puts(sel->text_output);
-			#else
-				puts(sel->text);
-			#endif // SEPARATOR_PATCH
-			#elif SEPARATOR_PATCH
-			puts(sel->text_output);
-			#else
-			puts(sel->text);
-			#endif // PRINTINDEX_PATCH | SEPARATOR_PATCH
-		} else {
-			if (text[0] == startpipe[0]) {
-				strncpy(text + strlen(text),pipeout,8);
-				puts(text+1);
-			}
-			puts(text);
-		}
-		#elif PRINTINPUTTEXT_PATCH
-		if (use_text_input) {
-			#if SEPARATOR_PATCH
-			puts((sel && (ev->state & ShiftMask)) ? sel->text_output : text);
-			#else
-			puts((sel && (ev->state & ShiftMask)) ? sel->text : text);
-			#endif // SEPARATOR_PATCH
-		#if PRINTINDEX_PATCH
-		} else if (print_index) {
-			printf("%d\n", (sel && !(ev->state & ShiftMask)) ? sel->index : -1);
-		#endif // PRINTINDEX_PATCH
-		} else {
-			#if SEPARATOR_PATCH
-			puts((sel && !(ev->state & ShiftMask)) ? sel->text_output : text);
-			#else
-			puts((sel && !(ev->state & ShiftMask)) ? sel->text : text);
-			#endif // SEPARATOR_PATCH
-		}
-		#elif PRINTINDEX_PATCH
-		if (print_index) {
-			printf("%d\n", (sel && !(ev->state & ShiftMask)) ? sel->index : -1);
-		} else {
-			#if SEPARATOR_PATCH
-			puts((sel && !(ev->state & ShiftMask)) ? sel->text_output : text);
-			#else
-			puts((sel && !(ev->state & ShiftMask)) ? sel->text : text);
-			#endif // SEPARATOR_PATCH
-		}
-		#elif SEPARATOR_PATCH
-		puts((sel && !(ev->state & ShiftMask)) ? sel->text_output : text);
-		#else
-		puts((sel && !(ev->state & ShiftMask)) ? sel->text : text);
-		#endif // PIPEOUT_PATCH | PRINTINPUTTEXT_PATCH | PRINTINDEX_PATCH
+		printcurrent(ev->state);
 		#endif // MULTI_SELECTION_PATCH
-		#if NAVHISTORY_PATCH && !MULTI_SELECTION_PATCH
-		if (ev->state & ShiftMask || !sel) {
-			addhistory(text);
-		} else {
-			addhistoryitem(sel);
-		}
-		#endif // NAVHISTORY_PATCH
 		if (!(ev->state & ControlMask)) {
 			#if MULTI_SELECTION_PATCH
-			printsel(ev->state);
+			printselected(ev->state);
 			#endif // MULTI_SELECTION_PATCH
 			cleanup();
 			exit(0);
@@ -1532,6 +1461,74 @@ paste(void)
 	drawmenu();
 }
 
+static void
+printitem(struct item *item)
+{
+	if (!item)
+		return;
+
+	#if NAVHISTORY_PATCH
+	addhistoryitem(item);
+	#endif // NAVHISTORY_PATCH
+
+	#if PIPEOUT_PATCH
+	if (item->text[0] == startpipe[0]) {
+		strncpy(item->text + strlen(item->text),pipeout,8);
+		puts(item->text+1);
+		return;
+	}
+	#endif // PIPEOUT_PATCH
+
+	#if PRINTINDEX_PATCH
+	if (print_index) {
+		printf("%d\n", item->index);
+		return;
+	}
+	#endif // PRINTINDEX_PATCH
+
+	#if SEPARATOR_PATCH
+	puts(item->text_output);
+	#else
+	puts(item->text);
+	#endif // SEPARATOR_PATCH
+}
+
+static void
+printtext(char *text)
+{
+	if (!text || !strlen(text))
+		return;
+
+	#if NAVHISTORY_PATCH
+	addhistory(text);
+	#endif // NAVHISTORY_PATCH
+
+	#if PIPEOUT_PATCH
+	if (text[0] == startpipe[0]) {
+		strncpy(text + strlen(text),pipeout,8);
+		puts(text+1);
+		return;
+	}
+	#endif // PIPEOUT_PATCH
+
+	puts(text);
+}
+
+static void
+printcurrent(unsigned int state)
+{
+	#if PRINTINPUTTEXT_PATCH
+	if (sel && (use_text_input == !!(state & ShiftMask)))
+	#else
+	if (sel && !(state & ShiftMask))
+	#endif // PRINTINPUTTEXT_PATCH
+	{
+		printitem(sel);
+	} else {
+		printtext(text);
+	}
+}
+
 #if ALPHA_PATCH
 static void
 xinitvisual(void)
@@ -1605,8 +1602,7 @@ readstdin(void)
 		if (!(items[i].text = strdup(line)))
 			die("strdup:");
 		#if SEPARATOR_PATCH
-		if (separator && (p = separator_greedy ?
-			strrchr(items[i].text, separator) : strchr(items[i].text, separator))) {
+		if (separator && (p = sepchr(items[i].text, separator)) != NULL) {
 			*p = '\0';
 			items[i].text_output = ++p;
 		} else {
@@ -2320,8 +2316,15 @@ main(int argc, char *argv[])
 			embed = argv[++i];
 		#endif // XRESOURCES_PATCH
 		#if SEPARATOR_PATCH
-		else if (!strcmp(argv[i], "-d") || /* field separator */
-				(separator_greedy = !strcmp(argv[i], "-D"))) {
+		else if (!strcmp(argv[i], "-d"))   /* field separator */
+		{
+			sepchr = strchr;
+			separator = argv[++i][0];
+			separator_reverse = argv[i][1] == '|';
+		}
+		else if (!strcmp(argv[i], "-D")) /* greedy field separator */
+		{
+			sepchr = strrchr;
 			separator = argv[++i][0];
 			separator_reverse = argv[i][1] == '|';
 		}

--- a/patch/dynamicoptions.c
+++ b/patch/dynamicoptions.c
@@ -34,8 +34,7 @@ readstream(FILE* stream)
 		if (!(items[i].text = strdup(buf)))
 			die("cannot strdup %u bytes:", strlen(buf) + 1);
 		#if SEPARATOR_PATCH
-		if (separator && (p = separator_greedy ?
-			strrchr(items[i].text, separator) : strchr(items[i].text, separator))) {
+		if (separator && (p = sepchr(items[i].text, separator)) != NULL) {
 			*p = '\0';
 			items[i].text_output = ++p;
 		} else {

--- a/patch/fuzzymatch.c
+++ b/patch/fuzzymatch.c
@@ -105,7 +105,7 @@ fuzzymatch(void)
 
 	#if INSTANT_PATCH
 	if (instant && matches && matches==matchend) {
-		puts(matches->text);
+		printitem(matches);
 		cleanup();
 		exit(0);
 	}

--- a/patch/fzfexpect.c
+++ b/patch/fzfexpect.c
@@ -6,13 +6,7 @@ expect(char *expect, XKeyEvent *ev)
 	if (sel && expected && strstr(expected, expect)) {
 		if (expected && sel && !(ev->state & ShiftMask))
 			puts(expect);
-		for (int i = 0; i < selidsize; i++)
-			if (selid[i] != -1 && (!sel || sel->id != selid[i]))
-				puts(items[selid[i]].text);
-		if (sel && !(ev->state & ShiftMask)) {
-			puts(sel->text);
-		} else
-			puts(text);
+		printselected(ev->state);
 		cleanup();
 		exit(1);
 	} else if (!sel && expected && strstr(expected, expect)) {
@@ -27,7 +21,7 @@ expect(char *expect, XKeyEvent *ignored)
 {
 	if (sel && expected && strstr(expected, expect)) {
 		puts(expect);
-		puts(sel->text);
+		printitem(sel);
 		cleanup();
 		exit(1);
 	} else if (!sel && expected && strstr(expected, expect)){

--- a/patch/mousesupport.c
+++ b/patch/mousesupport.c
@@ -152,58 +152,13 @@ clickitem(struct item *item, XButtonEvent *ev)
 	#endif // RESTRICT_RETURN_PATCH
 
 	#if !MULTI_SELECTION_PATCH
-	#if PIPEOUT_PATCH
-	if (item && !(ev->state & ShiftMask))
-	{
-		if (item->text[0] == startpipe[0]) {
-			strncpy(item->text + strlen(item->text),pipeout,8);
-			puts(item->text+1);
-		}
-		#if PRINTINDEX_PATCH
-		if (print_index) {
-			printf("%d\n", item->index);
-		} else {
-		#if SEPARATOR_PATCH
-			puts(item->text_output);
-		#else
-			puts(item->text);
-		#endif // SEPARATOR_PATCH
-		}
-		#else
-		puts(item->text);
-		#endif // PRINTINDEX_PATCH
-	} else {
-		if (text[0] == startpipe[0]) {
-			strncpy(text + strlen(text),pipeout,8);
-			puts(text+1);
-		}
-		puts(text);
-	}
-	#elif PRINTINDEX_PATCH
-	if (print_index) {
-		printf("%d\n", item->index);
-	} else {
-		#if SEPARATOR_PATCH
-		puts(item->text_output);
-		#else
-		puts(item->text);
-		#endif // SEPARATOR_PATCH
-	}
-	#elif SEPARATOR_PATCH
-	puts(item->text_output);
-	#else
-	puts(item->text);
-	#endif // PIPEOUT_PATCH | PRINTINDEX_PATCH
+	printitem(item);
 	#endif // MULTI_SELECTION_PATCH
 
 	sel = item;
 	if (!(ev->state & ControlMask)) {
-		#if NAVHISTORY_PATCH
-		savehistory(item->text);
-		#endif // NAVHISTORY_PATCH
 		#if MULTI_SELECTION_PATCH
-		selsel();
-		printsel(ev->state);
+		printselected(ev->state);
 		#endif // MULTI_SELECTION_PATCH
 		cleanup();
 		exit(0);

--- a/patch/multiselect.c
+++ b/patch/multiselect.c
@@ -10,7 +10,7 @@ issel(size_t id)
 static void
 printsel(unsigned int state)
 {
-	for (int i = 0;i < selidsize;i++)
+	for (int i = 0;i < selidsize;i++) {
 		if (selid[i] != -1 && (!sel || sel->id != selid[i])) {
 			#if PRINTINDEX_PATCH
 			if (print_index)
@@ -26,7 +26,12 @@ printsel(unsigned int state)
 			#else
 			puts(items[selid[i]].text);
 			#endif // PRINTINDEX_PATCH | SEPARATOR_PATCH
+			#if NAVHISTORY_PATCH
+			addhistoryitem(&items[selid[i]]);
+			#endif // NAVHISTORY_PATCH
 		}
+	}
+
 	if (sel && !(state & ShiftMask)) {
 		#if PRINTINDEX_PATCH
 		if (print_index)
@@ -42,9 +47,15 @@ printsel(unsigned int state)
 		#else
 		puts(sel->text);
 		#endif // PRINTINDEX_PATCH | SEPARATOR_PATCH
-	} else
+		#if NAVHISTORY_PATCH
+		addhistoryitem(sel);
+		#endif // NAVHISTORY_PATCH
+	} else {
 		puts(text);
-
+		#if NAVHISTORY_PATCH
+		addhistory(text);
+		#endif // NAVHISTORY_PATCH
+	}
 }
 
 static void

--- a/patch/multiselect.c
+++ b/patch/multiselect.c
@@ -8,54 +8,15 @@ issel(size_t id)
 }
 
 static void
-printsel(unsigned int state)
+printselected(unsigned int state)
 {
-	for (int i = 0;i < selidsize;i++) {
+	for (int i = 0; i < selidsize; i++) {
 		if (selid[i] != -1 && (!sel || sel->id != selid[i])) {
-			#if PRINTINDEX_PATCH
-			if (print_index)
-				printf("%d\n", selid[i]);
-			else
-			#if SEPARATOR_PATCH
-				puts(items[selid[i]].text_output);
-			#else
-				puts(items[selid[i]].text);
-			#endif // SEPARATOR_PATCH
-			#elif SEPARATOR_PATCH
-			puts(items[selid[i]].text_output);
-			#else
-			puts(items[selid[i]].text);
-			#endif // PRINTINDEX_PATCH | SEPARATOR_PATCH
-			#if NAVHISTORY_PATCH
-			addhistoryitem(&items[selid[i]]);
-			#endif // NAVHISTORY_PATCH
+			printitem(&items[selid[i]]);
 		}
 	}
 
-	if (sel && !(state & ShiftMask)) {
-		#if PRINTINDEX_PATCH
-		if (print_index)
-			printf("%d\n", sel->index);
-		else
-		#if SEPARATOR_PATCH
-			puts(sel->text_output);
-		#else
-			puts(sel->text);
-		#endif // SEPARATOR_PATCH
-		#elif SEPARATOR_PATCH
-		puts(sel->text_output);
-		#else
-		puts(sel->text);
-		#endif // PRINTINDEX_PATCH | SEPARATOR_PATCH
-		#if NAVHISTORY_PATCH
-		addhistoryitem(sel);
-		#endif // NAVHISTORY_PATCH
-	} else {
-		puts(text);
-		#if NAVHISTORY_PATCH
-		addhistory(text);
-		#endif // NAVHISTORY_PATCH
-	}
+	printcurrent(state);
 }
 
 static void

--- a/patch/multiselect.h
+++ b/patch/multiselect.h
@@ -1,1 +1,2 @@
 static int issel(size_t id);
+static void printselected(unsigned int state);

--- a/patch/navhistory.c
+++ b/patch/navhistory.c
@@ -1,12 +1,24 @@
 static char *histfile;
 static char **history;
 static size_t histsz, histpos;
+static size_t cap = 0;
+static struct item *backup_items = NULL;
+
+void
+cleanhistory(void)
+{
+	int i;
+
+	for (i = 0; i < histsz; i++) {
+		free(history[i]);
+	}
+	free(history);
+}
 
 void
 loadhistory(void)
 {
 	FILE *fp = NULL;
-	static size_t cap = 0;
 	size_t llen;
 	char *line;
 
@@ -30,16 +42,8 @@ loadhistory(void)
 			break;
 		}
 
-		if (cap == histsz) {
-			cap += 64 * sizeof(char*);
-			history = realloc(history, cap);
-			if (!history) {
-				die("failed to realloc memory");
-			}
-		}
-		strtok(line, "\n");
-		history[histsz] = line;
-		histsz++;
+		addhistory(line);
+		free(line);
 	}
 	histpos = histsz;
 
@@ -89,38 +93,140 @@ navhistory(int dir)
 }
 
 void
-savehistory(char *input)
+addhistory(char *input)
 {
 	unsigned int i;
-	FILE *fp;
 
 	if (!histfile ||
 	    0 == maxhist ||
 	    0 == strlen(input)) {
-		goto out;
+		return;
 	}
+
+	strtok(input, "\n");
+
+	if (histnodup) {
+		for (i = 0; i < histsz; i++) {
+			if (!strcmp(input, history[i])) {
+				return;
+			}
+		}
+	}
+
+	if (cap == histsz) {
+		reallochistory();
+	}
+
+	history[histsz] = strdup(input);
+	histsz++;
+}
+
+void
+addhistoryitem(struct item *item)
+{
+	#if SEPARATOR_PATCH
+	if (separator && item->text_output && item->text != item->text_output) {
+		int histlen = strlen(item->text) + strlen(item->text_output) + 2;
+		char *histitem = ecalloc(histlen + 1, sizeof(char *));
+		snprintf(histitem, histlen, "%s%c%s", item->text, separator, item->text_output);
+		addhistory(histitem);
+		free(histitem);
+	} else {
+		addhistory(item->text);
+	}
+	#else
+	addhistory(item->text);
+	#endif // SEPARATOR_PATCH
+}
+
+void
+reallochistory(void)
+{
+	size_t oldcap = cap;
+	cap += 64;
+	char **newhistory = realloc(history, cap * sizeof *history);
+	if (!newhistory) {
+		die("failed to realloc memory");
+	}
+
+	history = newhistory;
+	memset(history + oldcap, 0, (cap - oldcap) * sizeof *history);
+}
+
+void
+togglehistoryitems(void)
+{
+	int i;
+	#if SEPARATOR_PATCH
+	char *p;
+	#endif // SEPARATOR_PATCH
+
+	if (!histfile)
+		return;
+
+	if (backup_items) {
+		restorebackupitems();
+		return;
+	}
+
+	backup_items = items;
+	items = calloc(histsz + 1, sizeof(struct item));
+	if (!items) {
+		die("cannot allocate memory");
+	}
+
+	for (i = 0; i < histsz; i++) {
+		items[i].text = strdup(history[i]);
+		#if SEPARATOR_PATCH
+		if (separator && (p = separator_greedy ?
+			strrchr(items[i].text, separator) : strchr(items[i].text, separator))) {
+			*p = '\0';
+			items[i].text_output = ++p;
+		} else {
+			items[i].text_output = items[i].text;
+		}
+		#endif // SEPARATOR_PATCH
+	}
+}
+
+void
+restorebackupitems(void)
+{
+	size_t i;
+
+	if (!backup_items)
+		return;
+
+	for (i = 0; items && items[i].text; ++i) {
+		free(items[i].text);
+	}
+	free(items);
+
+	items = backup_items;
+	backup_items = NULL;
+}
+
+void
+savehistory(void)
+{
+	unsigned int i;
+	FILE *fp;
+
+	if (!histfile || 0 == maxhist)
+		return;
 
 	fp = fopen(histfile, "w");
 	if (!fp) {
 		die("failed to open %s", histfile);
 	}
+
 	for (i = histsz < maxhist ? 0 : histsz - maxhist; i < histsz; i++) {
 		if (0 >= fprintf(fp, "%s\n", history[i])) {
 			die("failed to write to %s", histfile);
 		}
 	}
-	if (histsz == 0 || !histnodup || (histsz > 0 && strcmp(input, history[histsz-1]) != 0)) { /* TODO */
-		if (0 >= fputs(input, fp)) {
-			die("failed to write to %s", histfile);
-		}
-	}
+
 	if (fclose(fp)) {
 		die("failed to close file %s", histfile);
 	}
-
-out:
-	for (i = 0; i < histsz; i++) {
-		free(history[i]);
-	}
-	free(history);
 }

--- a/patch/navhistory.c
+++ b/patch/navhistory.c
@@ -131,12 +131,11 @@ addhistoryitem(struct item *item)
 		snprintf(histitem, histlen, "%s%c%s", item->text, separator, item->text_output);
 		addhistory(histitem);
 		free(histitem);
-	} else {
-		addhistory(item->text);
+		return;
 	}
-	#else
-	addhistory(item->text);
 	#endif // SEPARATOR_PATCH
+
+	addhistory(item->text);
 }
 
 void
@@ -178,8 +177,7 @@ togglehistoryitems(void)
 	for (i = 0; i < histsz; i++) {
 		items[i].text = strdup(history[i]);
 		#if SEPARATOR_PATCH
-		if (separator && (p = separator_greedy ?
-			strrchr(items[i].text, separator) : strchr(items[i].text, separator))) {
+		if (separator && (p = sepchr(items[i].text, separator)) != NULL) {
 			*p = '\0';
 			items[i].text_output = ++p;
 		} else {

--- a/patch/navhistory.c
+++ b/patch/navhistory.c
@@ -156,7 +156,7 @@ void
 togglehistoryitems(void)
 {
 	int i;
-	#if SEPARATOR_PATCH
+	#if SEPARATOR_PATCH || TSV_PATCH
 	char *p;
 	#endif // SEPARATOR_PATCH
 
@@ -183,6 +183,10 @@ togglehistoryitems(void)
 		} else {
 			items[i].text_output = items[i].text;
 		}
+		#elif TSV_PATCH
+		items[i].stext = strdup(items[i].text);
+		if ((p = strchr(items[i].stext, '\t')))
+			*p = '\0';
 		#endif // SEPARATOR_PATCH
 	}
 }

--- a/patch/navhistory.h
+++ b/patch/navhistory.h
@@ -1,3 +1,9 @@
+static void addhistory(char *input);
+static void addhistoryitem(struct item *item);
+static void cleanhistory(void);
 static void loadhistory(void);
 static void navhistory(int dir);
-static void savehistory(char *input);
+static void reallochistory(void);
+static void restorebackupitems(void);
+static void savehistory(void);
+static void togglehistoryitems(void);

--- a/patch/vi_mode.c
+++ b/patch/vi_mode.c
@@ -146,13 +146,25 @@ vi_keypress(KeySym ksym, const XKeyEvent *ev)
 	/* misc. */
 	case XK_Return:
 	case XK_KP_Enter:
-		puts((sel && !(ev->state & ShiftMask)) ? sel->text : text);
+		#if RESTRICT_RETURN_PATCH
+		if (restrict_return && (!sel || ev->state & (ShiftMask | ControlMask)))
+			break;
+		#endif // RESTRICT_RETURN_PATCH
+		#if !MULTI_SELECTION_PATCH
+		printcurrent(ev->state);
+		#endif // MULTI_SELECTION_PATCH
 		if (!(ev->state & ControlMask)) {
+			#if MULTI_SELECTION_PATCH
+			printselected(ev->state);
+			#endif // MULTI_SELECTION_PATCH
 			cleanup();
 			exit(0);
 		}
+		#if !MULTI_SELECTION_PATCH
 		if (sel)
 			sel->out = 1;
+		#endif // MULTI_SELECTION_PATCH
+		break;
 		break;
 	case XK_Tab:
 		if (!sel)


### PR DESCRIPTION
uses https://tools.suckless.org/dmenu/patches/navhistory/dmenu-navhistory+search-20250328-52fc8a0.diff. tries to resolve conflict with `FZFEXPECT_PATCH` by ignoring the behavior of `C-R` in fzfexpect in favor of `NAVHISTORY_PATCH`